### PR TITLE
feat(web_environment_banner): adds a server wide web_environment_banner

### DIFF
--- a/setup/web_environment_banner/odoo/addons/web_environment_banner
+++ b/setup/web_environment_banner/odoo/addons/web_environment_banner
@@ -1,0 +1,1 @@
+../../../../web_environment_banner

--- a/setup/web_environment_banner/setup.py
+++ b/setup/web_environment_banner/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/web_environment_banner/README.rst
+++ b/web_environment_banner/README.rst
@@ -1,0 +1,21 @@
+======================
+web_environment_banner
+======================
+
+When the configuration file has something like the following set: ::
+
+    [web_environment_banner]
+    enabled = true
+    name = DEVELOPMENT: {hostname}
+
+An obvious banner is placed across the top of the frontend, backend, and
+web/database/manager.
+
+If the configuration is not enabled, then nothing happens.
+
+This module was inspired by the OCA/web/web_environment_banner module, however
+this moves it "up the stack" allowing it to function based on the
+instance/server level rather than the database level.
+
+This module is intended to be used as a server_wide_module.
+

--- a/web_environment_banner/__init__.py
+++ b/web_environment_banner/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import controllers

--- a/web_environment_banner/__manifest__.py
+++ b/web_environment_banner/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    "name": "web_environment_banner",
+    "summary": "Displays a banner across backend, frontend and /web/database/manager",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/web",
+    "category": "Uncategorized",
+    "version": "15.0.1.0.0",
+    "depends": ["web"],
+    "auto_install": True,
+    "data": [
+        "views/web_layout.xml",
+    ],
+    "license": "LGPL-3",
+}

--- a/web_environment_banner/controllers/__init__.py
+++ b/web_environment_banner/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import database

--- a/web_environment_banner/controllers/database.py
+++ b/web_environment_banner/controllers/database.py
@@ -1,0 +1,22 @@
+from lxml import html
+
+from odoo.http import request
+
+from odoo.addons.web.controllers.main import Database
+
+
+class Database(Database):
+    def _render_template(self, **d):
+        data = super()._render_template(**d)
+
+        enabled = request.env["web.environment.banner"]._enabled()
+        if enabled:
+            m = html.fromstring(data)
+            first = m.xpath("//body")[0]
+            first.insert(
+                0, html.fromstring(request.env["web.environment.banner"]._render())
+            )
+
+            data = html.tostring(m)
+
+        return data

--- a/web_environment_banner/models/__init__.py
+++ b/web_environment_banner/models/__init__.py
@@ -1,0 +1,1 @@
+from . import web_env_systray

--- a/web_environment_banner/models/web_env_systray.py
+++ b/web_environment_banner/models/web_env_systray.py
@@ -1,0 +1,78 @@
+import socket
+
+from markupsafe import escape
+
+from odoo import api, models, tools
+from odoo.tools import config
+
+CONFIG = config.misc.get("web_environment_banner", {})
+
+
+class EnvironmentBanner(models.AbstractModel):
+    _name = "web.environment.banner"
+    _description = "Web Env Systray"
+
+    @api.model
+    def _prepare_variables(self):
+        return {
+            "hostname": socket.gethostname(),
+        }
+
+    @api.model
+    def _enabled(self):
+        return tools.str2bool(CONFIG.get("enabled", "false")) and CONFIG.get("name")
+
+    @api.model
+    @tools.ormcache()
+    def _get_data(self):
+        if not self._enabled():
+            return
+
+        name_tmpl = CONFIG.get("name")
+
+        try:
+            name = (
+                name_tmpl and name_tmpl.format(**self._prepare_variables()) or name_tmpl
+            )
+        except KeyError as e:
+            name = "%s (unknown key '%s')" % (name_tmpl, str(e))
+
+        return {
+            "name": name,
+            "bgcolour": CONFIG.get("bgcolour", "#FFDC00"),
+            "fgcolour": CONFIG.get("fgcolour", "#000000"),
+        }
+
+    @api.model
+    @tools.ormcache()
+    def _render(self):
+        data = self._get_data()
+        if not data:
+            return
+
+        return """
+        <div style="
+             border: 10px solid {bgcolour};
+             border-image: repeating-linear-gradient(
+                -45deg,
+                {fgcolour},
+                {fgcolour} 20px,
+                {bgcolour} 20px,
+                {bgcolour} 40px
+              ) 10;
+            background-color: {bgcolour};
+            font-white: bold;
+            color: {fgcolour};
+            text-transform: uppercase;
+            font-family: monospace;
+            font-size: 1.1em;
+            box-sizing: border-box;
+            padding: 0 1em; text-align: center
+        ">
+            {name}
+        </div>
+        """.format(
+            bgcolour=escape(data.get("bgcolour")),
+            fgcolour=escape(data.get("fgcolour")),
+            name=escape(data.get("name")),
+        )

--- a/web_environment_banner/views/web_layout.xml
+++ b/web_environment_banner/views/web_layout.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <record id="web_layout" model="ir.ui.view">
+        <field name="name">web_layout</field>
+        <field name="model" />
+        <field name="priority">8</field>
+        <field name="inherit_id" ref="web.layout" />
+        <field name="arch" type="xml">
+            <xpath expr="//body/*[1]" position="before">
+                <t t-raw="request.env['web.environment.banner']._render()" />
+            </xpath>
+        </field>
+
+    </record>
+</odoo>


### PR DESCRIPTION
Adds an obtuse banner to backend, frontend and web/database/manager to ensure that there is no excuse for "I didn't realise which environment I was on".

Example module functionality:

![image](https://user-images.githubusercontent.com/309967/211630225-39f7dbb5-97af-4883-ba59-e6410bee3ed0.png)

TODO:

- [ ] Tests
