### PR TITLE
feat(concurrency_warning): initial migration of concurrency_warning module, fixes T9127

### DIFF
--- a/concurrency_warning/README.rst
+++ b/concurrency_warning/README.rst
@@ -1,0 +1,32 @@
+-------------------
+concurrency_warning
+-------------------
+
+When a user is viewing a record within the Odoo backend web UI, and the record
+is changed, when configured the system will notify the user that the record has
+changed and reload the record.
+
+Additional configuration is required per-model to enable this feature. This is
+by design to ensure that we do not effectively spam the user about records they
+do not care about.
+
+Example usage
+--------------
+
+::
+
+    <record id="poke_sale_order_on_write" model="base.automation">
+      <field name="name">Poke on Sale Order Change</field>
+      <field name="model_id" ref="sale.model_sale_order"/>
+      <field name="state">poke</field>
+      <field name="trigger">on_write</field>
+    </record>
+
+    <record id="poke_purchase_order_on_write" model="base.automation">
+      <field name="name">Poke on Purchase Order Change</field>
+      <field name="model_id" ref="purchase.model_purchase_order"/>
+      <field name="state">poke</field>
+      <field name="trigger">on_write</field>
+    </record>
+
+

--- a/concurrency_warning/__init__.py
+++ b/concurrency_warning/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/concurrency_warning/__manifest__.py
+++ b/concurrency_warning/__manifest__.py
@@ -1,0 +1,21 @@
+{
+    "name": "concurrency_warning",
+    "summary": "Issue a visual warning and reload the page content if a user"
+    " has left a model open, and it been altered in the meantime.",
+    "author": "Glo Networks",
+    "website": "https://github.com/GlodoUK/web",
+    "category": "Uncategorized",
+    "version": "16.0.1.0.0",
+    "depends": [
+        "bus",
+        "base",
+    ],
+    "data": [
+        "views/ir_actions_server.xml",
+    ],
+    "demo": [],
+    "license": "LGPL-3",
+    "assets": {
+        "web.assets_backend": ["/concurrency_warning/static/src/js/poke.esm.js"],
+    },
+}

--- a/concurrency_warning/models/__init__.py
+++ b/concurrency_warning/models/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/concurrency_warning/models/models.py
+++ b/concurrency_warning/models/models.py
@@ -1,0 +1,52 @@
+from odoo import fields, models
+
+
+class ServerActions(models.Model):
+    _inherit = "ir.actions.server"
+
+    state = fields.Selection(
+        selection_add=[("poke", "Prompt user that record has changed")],
+        ondelete={"poke": "cascade"},
+    )
+    poke_msg = fields.Text(
+        default="This record has been changed by another user since you opened"
+        " it. The record has been automatically refreshed."
+    )
+    poke_refresh = fields.Boolean(default=True)
+    poke_sticky = fields.Boolean(default=False)
+    poke_type = fields.Selection(
+        [
+            ("info", "Info"),
+            ("warning", "Warning"),
+            ("danger", "Danger"),
+            ("success", "Success"),
+        ],
+        default="warning",
+    )
+
+    def _run_action_poke_multi(self, eval_context=None):
+        if eval_context is None:
+            eval_context = {}
+
+        records = eval_context.get("records") or eval_context.get("record")
+        if not records:
+            return False
+
+        bcast = self._run_action_poke_multi_broadcast_vals(records)
+
+        if not bcast:
+            return False
+
+        self.env["bus.bus"]._sendone("broadcast", "poke", bcast)
+
+        return False
+
+    def _run_action_poke_multi_broadcast_vals(self, records):
+        return {
+            "uid": self.env.uid,
+            "model": self.model_name,
+            "ids": records.ids,
+            "msg": self.poke_msg,
+            "type": self.poke_type,
+            "refresh": self.poke_refresh,
+        }

--- a/concurrency_warning/static/src/js/poke.esm.js
+++ b/concurrency_warning/static/src/js/poke.esm.js
@@ -1,0 +1,48 @@
+/** @odoo-module **/
+import {debounce} from "@web/core/utils/timing";
+import {registry} from "@web/core/registry";
+
+export const concurrencyWarningService = {
+    dependencies: ["bus_service", "notification", "action", "user"],
+
+    start(env, {bus_service, notification, action, user}) {
+        const _doNotify = debounce(function (payload) {
+            if (payload.refresh) {
+                action.loadState();
+            }
+
+            notification.add(payload.msg, {
+                title: env._t("Record changed"),
+                type: payload.type || "warning",
+                sticky: payload.sticky || false,
+            });
+        }, 1000);
+
+        bus_service.addEventListener("notification", ({detail: notifications}) => {
+            for (const {payload, type} of notifications) {
+                if (type !== "poke") {
+                    continue;
+                }
+
+                if (
+                    !action ||
+                    !action.currentController ||
+                    user.userId === payload.uid
+                ) {
+                    continue;
+                }
+
+                if (
+                    action.currentController.props.resModel === payload.model &&
+                    payload.ids.includes(action.currentController.props.resId) &&
+                    !action.currentController.view.multiRecord
+                ) {
+                    _doNotify(payload);
+                }
+            }
+        });
+        bus_service.start();
+    },
+};
+
+registry.category("services").add("concurrencyWarning", concurrencyWarningService);

--- a/concurrency_warning/views/ir_actions_server.xml
+++ b/concurrency_warning/views/ir_actions_server.xml
@@ -1,0 +1,22 @@
+<odoo>
+    <record model="ir.ui.view" id="view_server_action_form">
+        <field name="name">view_server_action_form</field>
+        <field name="model">ir.actions.server</field>
+        <field name="inherit_id" ref="base.view_server_action_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page
+                    string="Poke"
+                    name="poke"
+                    attrs="{'invisible': [('state', '!=', 'poke')]}"
+                >
+                    <group>
+                        <field name="poke_msg" />
+                        <field name="poke_refresh" />
+                        <field name="poke_type" />
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/setup/concurrency_warning/odoo/addons/concurrency_warning
+++ b/setup/concurrency_warning/odoo/addons/concurrency_warning
@@ -1,0 +1,1 @@
+../../../../concurrency_warning

--- a/setup/concurrency_warning/setup.py
+++ b/setup/concurrency_warning/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)

--- a/web_list_min_width/static/src/js/list_renderer.esm.js
+++ b/web_list_min_width/static/src/js/list_renderer.esm.js
@@ -5,7 +5,7 @@ import {patch} from "@web/core/utils/patch";
 
 patch(ListRenderer.prototype, "web_list_min_width", {
     calculateColumnWidth(column) {
-        // backwards compat
+        // Backwards compat
         if (
             column.rawAttrs !== undefined &&
             column.rawAttrs["min-width"] !== undefined
@@ -16,10 +16,7 @@ patch(ListRenderer.prototype, "web_list_min_width", {
             };
         }
 
-        if (
-            column.options !== undefined &&
-            column.options['min-width'] !== undefined
-        ) {
+        if (column.options !== undefined && column.options["min-width"] !== undefined) {
             return {
                 type: "absolute",
                 value: column.options["min-width"],


### PR DESCRIPTION
## Description

Initial migration of concurrency_warning module.

Significant changes since 15.0:
  * poke message is now configurable
  * poke message removes the user's name by default
  * poke auto-refresh is now configurable
  * notification type is configurable
  * notification sticky-ness is configurable
  * upgrade javascript to use the `bus` service instead of the legacy hack
  * removed direct dependency on base_automation as it is not strictly required

Fixes T9127
Associated risk level low

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Suggested UAT/Review Steps

If applicable please list any steps that the end user may require to verify or test the new behaviour.

