### PR TITLE
feat(web_list_min_width): add options support, adds initial width support, retains legacy fallback support

### DIFF
--- a/web_list_min_width/README.rst
+++ b/web_list_min_width/README.rst
@@ -2,10 +2,32 @@
 web_list_min_width
 ==================
 
-Allows the attribute `min-width` to be set and enforced on a list / tree view.
+- Adds a min-width field option to force a minimum width on a field
+- Adds an 'initial-width' field option to force initial width on a field
 
 Usage
 =====
+
+Set an option called `min-width` on a field with an appropriate unit::
+
+  <xpath expr="//field[@name='order_line']/tree/field[@name='product_id']" position="attributes">
+    <attribute name="options">{'min-width': '12rem'}</xpath>
+  </xpath>
+
+
+Set an option called `initial-width` on a field with an appropriate unit::
+
+  <xpath expr="//field[@name='order_line']/tree/field[@name='product_id']" position="attributes">
+    <attribute name="options">{'initial-width': '16rem'}</xpath>
+  </xpath>
+
+
+Deprecated
+----------
+
+For backwards compatibility an attribute called "min-width" is supported,
+however this is non-functional on fields outside of forms. The options approach
+is recommended going forward.
 
 Set an attribute called `min-width` on a field with an appropriate unit::
 

--- a/web_list_min_width/static/src/js/list_renderer.js
+++ b/web_list_min_width/static/src/js/list_renderer.js
@@ -2,23 +2,77 @@ odoo.define("web_list_min_width.ListRenderer", function (require) {
     "use strict";
 
     const ListRenderer = require("web.ListRenderer");
+    const pyUtils = require("web.py_utils");
     ListRenderer.include({
+        _getColMinWidth: function (column) {
+            // Backwards compat - allow an attr called "min-width".
+            // This is not recommended going forward as it does not work
+            // properly outside of forms.
+            if (column.attrs["min-width"]) {
+                return column.attrs["min-width"];
+            }
+
+            if (column.attrs.options !== undefined) {
+                const options = _.isObject(column.attrs.options)
+                    ? column.attrs.options
+                    : pyUtils.py_eval(column.attrs.options);
+
+                if (options["min-width"] !== undefined) {
+                    return options["min-width"];
+                }
+            }
+        },
+
+        _getColInitialWidth: function (column) {
+            if (column.attrs.options !== undefined) {
+                const options = _.isObject(column.attrs.options)
+                    ? column.attrs.options
+                    : pyUtils.py_eval(column.attrs.options);
+
+                if (options["initial-width"] !== undefined) {
+                    return options["initial-width"];
+                }
+            }
+        },
+
+        _updateColumnMinInitialWidths: function (th, column) {
+            const minWidth = this._getColMinWidth(column);
+            const initialWidth = this._getColInitialWidth(column);
+
+            if (minWidth === undefined && initialWidth === undefined) {
+                return th;
+            }
+
+            if (minWidth || initialWidth) {
+                th.style.width = "";
+                th.style.wordWrap = "break-word";
+            }
+
+            if (minWidth !== undefined) {
+                th.style.minWidth = minWidth;
+            }
+
+            if (initialWidth !== undefined) {
+                th.style.width = initialWidth;
+                th.style.maxWidth = initialWidth;
+            }
+
+            return th;
+        },
+
         /**
          * @override
          * @private
          */
         _computeDefaultWidths: function () {
-            this._super.apply(this, arguments);
+            const res = this._super.apply(this, arguments);
 
             this.columns.forEach((column) => {
-                if (!column.attrs["min-width"]) {
-                    return;
-                }
-
                 const th = this._getColumnHeader(column);
-                th.style.minWidth = column.attrs["min-width"];
-                th.style.width = "";
+                this._updateColumnMinInitialWidths(th, column);
             });
+
+            return res;
         },
 
         /**
@@ -27,10 +81,7 @@ odoo.define("web_list_min_width.ListRenderer", function (require) {
          */
         _renderHeaderCell: function (node) {
             const $th = this._super.apply(this, arguments);
-            if (node.attrs["min-width"]) {
-                $th[0].style.minWidth = node.attrs["min-width"];
-                $th[0].style.width = "";
-            }
+            this._updateColumnMinInitialWidths($th[0], node);
             return $th;
         },
     });


### PR DESCRIPTION
## Description

`min-width` as an attribute only works in forms, by accident. I don't think this is actually intentional, as Odoo validates what attributes are valid and it's fiddly to add extras.

This adds the following:

- `options` support as per other Odoo fields i.e. `<field name="name" options="{'min-width': 12rem, 'initial-width': '14rem'}" />`
- Deprecates the form `<field name="name" min-width="12rem"/>`
- Adds the ability to force an initial width

Fixes GH111200

Associated risk level low

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

